### PR TITLE
Use buffer-substring rather that buffer-substring-no-properties

### DIFF
--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -227,7 +227,7 @@ be passed to EVAL-FUNC as its rest arguments"
   "Evil operator to query and replace a region throughout the current buffer"
   :move-point nil
   (interactive "<r>")
-  (let ((replaced-string (filter-buffer-substring beg end nil))
+  (let ((replaced-string (buffer-substring-no-properties beg end nil))
         (replacement-str (read-string "Replace with:")))
     (goto-char (point-min))
     (query-replace (regexp-quote replaced-string) replacement-str)
@@ -238,7 +238,7 @@ be passed to EVAL-FUNC as its rest arguments"
   :move-point nil
   (interactive "<r>")
   (let* (
-        (content (filter-buffer-substring beg end nil))
+        (content (buffer-substring-no-properties beg end nil))
         (contains-new-line (not (null (string-match "\n" content))))
         (ends-with-newline (not (null (string-match "\n\\'" content))))
         (new-line-spec (list contains-new-line ends-with-newline)))

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -236,15 +236,12 @@ be passed to EVAL-FUNC as its rest arguments"
 (evil-define-operator evil-operator-clone (beg end type)
   "Evil operator to create a clone of a motion"
   :move-point nil
-  (interactive "<R>")
+  (interactive "<r>")
   (let* (
         (content (filter-buffer-substring beg end nil))
         (contains-new-line (not (null (string-match "\n" content))))
         (ends-with-newline (not (null (string-match "\n\\'" content))))
         (new-line-spec (list contains-new-line ends-with-newline)))
-
-    (message (format "%S" type))
-    (message (format "%S" content))
     (goto-char beg)
     (insert
      (cond

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -33,7 +33,8 @@
 ;; Commands provided by this package:
 ;; evil-operator-eval, evil-operator-google-translate,
 ;; evil-operator-google-search, evil-operator-highlight, evil-operator-fold,
-;; evil-operator-org-capture, evil-operator-remember 
+;; evil-operator-org-capture, evil-operator-remember, evil-operator-clone,
+;; evil-operator-query-replace
 ;;
 ;; Installation:
 ;;
@@ -215,6 +216,25 @@ be passed to EVAL-FUNC as its rest arguments"
           (run-hooks 'remember-handler-functions)
         (run-hook-with-args-until-success 'remember-handler-functions))
       (remember-destroy))))
+
+(evil-define-operator evil-operator-query-replace (beg end type)
+  "Query replace the motion in the buffer"
+  (let ((replaced-string (filter-buffer-substring beg end nil))
+        (replacement-str (read-string "Replace with:")))
+    (save-excursion
+      (goto-char (point-min))
+      (query-replace (regexp-quote replaced-string) replacement-str)
+                    (kill-new replaced-string))))
+
+(evil-define-operator evil-operator-clone (beg end type)
+  "Clone the selected motion"
+  (let (
+        (content (filter-buffer-substring beg end nil)))
+    (save-excursion
+      (goto-char beg)
+      (beginning-of-line)
+      (insert (concat content "\n")))))
+
 
 ;;;###autoload
 (define-minor-mode evil-extra-operator-mode

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -225,23 +225,23 @@ be passed to EVAL-FUNC as its rest arguments"
 
 (evil-define-operator evil-operator-query-replace (beg end type)
   "Evil operator to query and replace a region throughout the current buffer"
+  :move-point nil
   (interactive "<r>")
   (let ((replaced-string (filter-buffer-substring beg end nil))
         (replacement-str (read-string "Replace with:")))
-    (save-excursion
-      (goto-char (point-min))
-      (query-replace (regexp-quote replaced-string) replacement-str)
-                    (kill-new replaced-string))))
+    (goto-char (point-min))
+    (query-replace (regexp-quote replaced-string) replacement-str)
+    (kill-new replaced-string)))
 
 (evil-define-operator evil-operator-clone (beg end type)
   "Evil operator to create a clone of a motion"
+  :move-point nil
   (interactive "<r>")
   (let (
         (content (filter-buffer-substring beg end nil)))
-    (save-excursion
-      (goto-char beg)
-      (beginning-of-line)
-      (insert (concat content "\n")))))
+    (goto-char beg)
+    (beginning-of-line)
+    (insert (concat content "\n"))))
 
 
 ;;;###autoload

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -225,6 +225,7 @@ be passed to EVAL-FUNC as its rest arguments"
 
 (evil-define-operator evil-operator-query-replace (beg end type)
   "Evil operator to query and replace a region throughout the current buffer"
+  (interactive "<r>")
   (let ((replaced-string (filter-buffer-substring beg end nil))
         (replacement-str (read-string "Replace with:")))
     (save-excursion
@@ -234,6 +235,7 @@ be passed to EVAL-FUNC as its rest arguments"
 
 (evil-define-operator evil-operator-clone (beg end type)
   "Evil operator to create a clone of a motion"
+  (interactive "<r>")
   (let (
         (content (filter-buffer-substring beg end nil)))
     (save-excursion

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -168,10 +168,10 @@ be passed to EVAL-FUNC as its rest arguments"
   (if (eq type 'block)
       (let ((s nil))
         (evil-apply-on-block
-         (lambda (b e) (setq s (cons (buffer-substring-no-properties b e) s)))
+         (lambda (b e) (setq s (cons (buffer-substring b e) s)))
          beg end nil)
         (mapconcat 'identity (nreverse s) " "))
-    (buffer-substring-no-properties beg end)))
+    (buffer-substring beg end)))
 
 (evil-define-operator evil-operator-highlight (beg end type)
   "Evil operator for region highlight."
@@ -212,10 +212,10 @@ be passed to EVAL-FUNC as its rest arguments"
               (progn
                 (evil-apply-on-block
                  (lambda (b e)
-                   (setq s (cons (buffer-substring-no-properties b e) s)))
+                   (setq s (cons (buffer-substring b e) s)))
                  beg end nil)
                 (mapconcat 'identity (nreverse s) "\n"))
-            (buffer-substring-no-properties beg end))))
+            (buffer-substring beg end))))
     (with-temp-buffer
       (insert cont)
       (if remember-all-handler-functions
@@ -227,7 +227,7 @@ be passed to EVAL-FUNC as its rest arguments"
   "Evil operator to query and replace a region throughout the current buffer"
   :move-point nil
   (interactive "<r>")
-  (let ((replaced-string (buffer-substring-no-properties beg end nil))
+  (let ((replaced-string (buffer-substring beg end nil))
         (replacement-str (read-string "Replace with:")))
     (goto-char (point-min))
     (query-replace (regexp-quote replaced-string) replacement-str)
@@ -238,7 +238,7 @@ be passed to EVAL-FUNC as its rest arguments"
   :move-point nil
   (interactive "<r>")
   (let* (
-        (content (buffer-substring-no-properties beg end nil))
+        (content (buffer-substring beg end nil))
         (contains-new-line (not (null (string-match "\n" content))))
         (ends-with-newline (not (null (string-match "\n\\'" content))))
         (new-line-spec (list contains-new-line ends-with-newline)))

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -236,12 +236,22 @@ be passed to EVAL-FUNC as its rest arguments"
 (evil-define-operator evil-operator-clone (beg end type)
   "Evil operator to create a clone of a motion"
   :move-point nil
-  (interactive "<r>")
-  (let (
-        (content (filter-buffer-substring beg end nil)))
+  (interactive "<R>")
+  (let* (
+        (content (filter-buffer-substring beg end nil))
+        (contains-new-line (not (null (string-match "\n" content))))
+        (ends-with-newline (not (null (string-match "\n\\'" content))))
+        (new-line-spec (list contains-new-line ends-with-newline)))
+
+    (message (format "%S" type))
+    (message (format "%S" content))
     (goto-char beg)
-    (beginning-of-line)
-    (insert (concat content "\n"))))
+    (insert
+     (cond
+      ((equal new-line-spec '(t t)) content)
+      ((equal new-line-spec '(t nil)) (concat content "\n"))
+      ((equal new-line-spec '(nil nil)) content)
+      (t content)))))
 
 
 ;;;###autoload

--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -123,6 +123,12 @@ be passed to EVAL-FUNC as its rest arguments"
 ;;;###autoload
 (autoload 'evil-operator-remember "evil-extra-operator"
   "Evil operator for remember-region" t)
+;;;###autoload
+(autoload 'evil-operator-query-replace "evil-extra-operator"
+  "Evil operator to query and replace a region throughout the current buffer" t)
+;;;###autoload
+(autoload 'evil-operator-clone "evil-extra-operator"
+  "Evil operator to create a clone of a motion" t)
 
 
 (evil-define-operator evil-operator-eval (beg end)
@@ -218,7 +224,7 @@ be passed to EVAL-FUNC as its rest arguments"
       (remember-destroy))))
 
 (evil-define-operator evil-operator-query-replace (beg end type)
-  "Query replace the motion in the buffer"
+  "Evil operator to query and replace a region throughout the current buffer"
   (let ((replaced-string (filter-buffer-substring beg end nil))
         (replacement-str (read-string "Replace with:")))
     (save-excursion
@@ -227,7 +233,7 @@ be passed to EVAL-FUNC as its rest arguments"
                     (kill-new replaced-string))))
 
 (evil-define-operator evil-operator-clone (beg end type)
-  "Clone the selected motion"
+  "Evil operator to create a clone of a motion"
   (let (
         (content (filter-buffer-substring beg end nil)))
     (save-excursion


### PR DESCRIPTION
This branch extends tal--query-replace-and-clone which should be merged first.

This is what evil itself does.