### PR TITLE
Add an evil operator to replace contents with result from eval

### DIFF
--- a/evil-extra-operator.el
+++ b/evil-extra-operator.el
@@ -106,6 +106,18 @@ be passed to EVAL-FUNC as its rest arguments"
   :type '(alist :key-type symbol)
   :group 'evil-extra-operator)
 
+(defcustom evil-extra-operator-eval-replace-modes-alist
+  '()
+  "Alist used to determine evil-operator-eval-replace's behaviour.
+Each element of this alist should be of this form:
+
+ (MAJOR-MODE EVAL-FUNC [ARGS...])
+
+MAJOR-MODE denotes the major mode of buffer. EVAL-FUNC should be a function
+with at least 2 arguments: the region beginning and the region end. ARGS will
+be passed to EVAL-FUNC as its rest arguments"
+  :type '(alist :key-type symbol)
+  :group 'evil-extra-operator)
 
 ;;;###autoload
 (autoload 'evil-operator-eval "evil-extra-operator"
@@ -135,6 +147,20 @@ be passed to EVAL-FUNC as its rest arguments"
 (autoload 'evil-operator-clone "evil-extra-operator"
   "Evil operator to create a clone of a motion" t)
 
+(evil-define-operator evil-operator-eval-replace (beg end)
+  "Evil operator for evaluating code."
+  :move-point nil
+  (interactive "<r>")
+  (let* ((ele (assoc major-mode evil-extra-operator-eval-replace-modes-alist))
+         (f-a (cdr-safe ele))
+         (func (car-safe f-a))
+         (args (cdr-safe f-a))
+         (text (buffer-substring-no-properties beg end))
+         (result (if (fboundp func)
+                     (apply func beg end args)
+                   (format "%s" (eval (read text))))))
+    (delete-region beg end)
+    (insert result)))
 
 (evil-define-operator evil-operator-eval (beg end)
   "Evil operator for evaluating code."


### PR DESCRIPTION
This PR creates a new operator which inserts the result of an eval into the buffer, replacing the evaluated expression.

See http://emacsredux.com/blog/2013/06/21/eval-and-replace/ 
or https://github.com/bbatsov/crux

for non-evil versions.

Let me know if you find any issues. I designed it like the existing eval operators, with extensibility in mind, but I couldn't find any equivalent functions for non-elisp languages (to insert results into the buffer)